### PR TITLE
fix(config): support for requiring global installed rule

### DIFF
--- a/lib/config/config-loader.js
+++ b/lib/config/config-loader.js
@@ -16,7 +16,7 @@ function load(configFilePath) {
     if (isConfigModule(configFilePath)) {
         // config as a module - shared config
         // FIXME: not tested function
-        return require(tryResolve.relative(configFilePath))
+        return require(tryResolve(configFilePath))
     } else {
         // auto or specify config file
         var config = configFilePath ? {config: configFilePath} : null;

--- a/lib/textlint-engine.js
+++ b/lib/textlint-engine.js
@@ -68,7 +68,7 @@ TextLintEngine.prototype.setupRules = function (config) {
             if (ruleManager.isDefinedRule(ruleName)) {
                 return;
             }
-            var pkgPath = tryResolve.relative("textlint-rule-" + ruleName) || tryResolve.relative(ruleName);
+            var pkgPath = tryResolve("textlint-rule-" + ruleName) || tryResolve(ruleName);
             if (pkgPath) {
                 debug("Loading rules from %s", pkgPath);
                 var plugin = require(pkgPath);


### PR DESCRIPTION
use `tryResolve` instead of `tryResolve.relative`
`tryResolve.relative` don't load global installed module.