### PR TITLE
accept both ruleName and rulePath

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -17,7 +17,7 @@ var defaultOptions = {
     // rule package names
     rules: [],
     // rule directory
-    ruleDirectory: '',
+    rulesBaseDirectory: '',
     // ".textlint" file path
     configFile: null,
     // rules config object

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -16,6 +16,8 @@ function availableRuleKeys(rulesConfig) {
 var defaultOptions = {
     // rule package names
     rules: [],
+    // rule directory
+    ruleDirectory: '',
     // ".textlint" file path
     configFile: null,
     // rules config object

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -17,7 +17,7 @@ var defaultOptions = {
     // rule package names
     rules: [],
     // rule directory
-    rulesBaseDirectory: '',
+    rulesBaseDirectory: null,
     // ".textlint" file path
     configFile: null,
     // rules config object

--- a/lib/textlint-engine.js
+++ b/lib/textlint-engine.js
@@ -70,26 +70,21 @@ TextLintEngine.prototype.setupRules = function (config) {
     textLint.setupRules(ruleManager.getAllRules(), config.rulesConfig);
 };
 /**
- * set directory to use as root directory to load rule.
- * @param {string} directory as root directory to load rule
- */
-TextLintEngine.prototype.setRuleDirectory = function (directory) {
-    this.ruleDirectory = directory;
-};
-/**
- * load rule file with `ruleName` and define rule.
+ * load rule file with `ruleName` or `rulePath` and define rule.
  * if rule is not found, then throw ReferenceError.
  * if already rule is loaded, do not anything.
- * @param {string} ruleName
+ * @param {string} ruleName or rulePath
  */
-TextLintEngine.prototype.loadRule = function (ruleName) {
+TextLintEngine.prototype.loadRule = function (rulePath) {
+    var isAbsolute = path.isAbsolute(rulePath);
+    var ruleName = isAbsolute ? rulePath.split(path.sep).pop() : rulePath;
+    var ruleDirectory = isAbsolute ? path.dirname(rulePath) : "";
     // ignore already defined rule
     // ignore rules from rulePaths because avoid ReferenceError is that try to require.
     if (ruleManager.isDefinedRule(ruleName)) {
         return;
     }
-    var directory = this.ruleDirectory || "";
-    var pkgPath = tryResolve(path.join(directory, "textlint-rule-" + ruleName)) || tryResolve(path.join(directory, ruleName));
+    var pkgPath = tryResolve(path.join(ruleDirectory, "textlint-rule-" + ruleName)) || tryResolve(path.join(ruleDirectory, ruleName));
     if (!pkgPath) {
         throw new ReferenceError(ruleName + " is not found");
     }

--- a/lib/textlint-engine.js
+++ b/lib/textlint-engine.js
@@ -83,8 +83,8 @@ TextLintEngine.prototype.addRule = function (ruleName) {
  * set directory to use as root directory to load rule.
  * @param {string} directory as root directory to load rule
  */
-TextLintEngine.prototype.setRuleDirectory = function (directory) {
-    this.config.ruleDirectory = directory;
+TextLintEngine.prototype.setRulesBaseDirectory = function (directory) {
+    this.config.rulesBaseDirectory = directory;
 };
 /**
  * load rule file with `ruleName` and define rule.
@@ -98,8 +98,8 @@ TextLintEngine.prototype.loadRule = function (ruleName) {
     if (ruleManager.isDefinedRule(ruleName)) {
         return;
     }
-    var ruleDirectory = this.config.ruleDirectory || "";
-    var pkgPath = tryResolve(path.join(ruleDirectory, "textlint-rule-" + ruleName)) || tryResolve(path.join(ruleDirectory, ruleName));
+    var directory = this.config.rulesBaseDirectory || "";
+    var pkgPath = tryResolve(path.join(directory, "textlint-rule-" + ruleName)) || tryResolve(path.join(directory, ruleName));
     if (!pkgPath) {
         throw new ReferenceError(ruleName + " is not found");
     }

--- a/lib/textlint-engine.js
+++ b/lib/textlint-engine.js
@@ -7,6 +7,7 @@ var Config = require("./config/config");
 var createFormatter = require("textlint-formatter");
 var tryResolve = require("try-resolve");
 var path = require("path");
+var pathIsAbsolute = require('path-is-absolute');
 var ruleManager = require("./rule/rule-manager");
 var debug = require("debug")("text:cli-engine");
 /**
@@ -76,7 +77,7 @@ TextLintEngine.prototype.setupRules = function (config) {
  * @param {string} ruleName or rulePath
  */
 TextLintEngine.prototype.loadRule = function (rulePath) {
-    var isAbsolute = path.isAbsolute(rulePath);
+    var isAbsolute = pathIsAbsolute(rulePath);
     var ruleName = isAbsolute ? rulePath.split(path.sep).pop() : rulePath;
     var ruleDirectory = isAbsolute ? path.dirname(rulePath) : "";
     // ignore already defined rule

--- a/lib/textlint-engine.js
+++ b/lib/textlint-engine.js
@@ -23,6 +23,7 @@ function TextLintEngine(options) {
     } else {
         this.config = new Config(options);
     }
+    this.setupRules(this.config);
 }
 /**
  * filter files by config
@@ -106,7 +107,6 @@ TextLintEngine.prototype.resetRules = function () {
  * @returns {TextLintResult[]} The results for all files that were linted.
  */
 TextLintEngine.prototype.executeOnFiles = function (files) {
-    this.setupRules(this.config);
     var targetFiles = findFiles(files, this.config);
     var results = targetFiles.map(function (file) {
         return textLint.lintFile(file);
@@ -122,7 +122,6 @@ TextLintEngine.prototype.executeOnFiles = function (files) {
  * @todo specify the files format for lint by config.filetype?
  */
 TextLintEngine.prototype.executeOnText = function (text) {
-    this.setupRules(this.config);
     var results = [textLint.lintText(text)];
     textLint.resetRules();
     return results;

--- a/lib/textlint-engine.js
+++ b/lib/textlint-engine.js
@@ -7,7 +7,6 @@ var Config = require("./config/config");
 var createFormatter = require("textlint-formatter");
 var tryResolve = require("try-resolve");
 var path = require("path");
-var pathIsAbsolute = require('path-is-absolute');
 var ruleManager = require("./rule/rule-manager");
 var debug = require("debug")("text:cli-engine");
 /**
@@ -71,20 +70,35 @@ TextLintEngine.prototype.setupRules = function (config) {
     textLint.setupRules(ruleManager.getAllRules(), config.rulesConfig);
 };
 /**
- * load rule file with `ruleName` or `rulePath` and define rule.
+ * add rule to config.rules
+ * if rule already exists, then not added 
+ * @param {string} 
+ */
+TextLintEngine.prototype.addRule = function (ruleName) {
+    if (Array.isArray(this.config.rules) && this.config.rules.indexOf(ruleName) === -1) {
+        this.config.rules.push(ruleName);
+    }
+};
+/**
+ * set directory to use as root directory to load rule.
+ * @param {string} directory as root directory to load rule
+ */
+TextLintEngine.prototype.setRuleDirectory = function (directory) {
+    this.config.ruleDirectory = directory;
+};
+/**
+ * load rule file with `ruleName` and define rule.
  * if rule is not found, then throw ReferenceError.
  * if already rule is loaded, do not anything.
- * @param {string} ruleName or rulePath
+ * @param {string} ruleName
  */
-TextLintEngine.prototype.loadRule = function (rulePath) {
-    var isAbsolute = pathIsAbsolute(rulePath);
-    var ruleName = isAbsolute ? rulePath.split(path.sep).pop() : rulePath;
-    var ruleDirectory = isAbsolute ? path.dirname(rulePath) : "";
+TextLintEngine.prototype.loadRule = function (ruleName) {
     // ignore already defined rule
     // ignore rules from rulePaths because avoid ReferenceError is that try to require.
     if (ruleManager.isDefinedRule(ruleName)) {
         return;
     }
+    var ruleDirectory = this.config.ruleDirectory || "";
     var pkgPath = tryResolve(path.join(ruleDirectory, "textlint-rule-" + ruleName)) || tryResolve(path.join(ruleDirectory, ruleName));
     if (!pkgPath) {
         throw new ReferenceError(ruleName + " is not found");

--- a/lib/textlint-engine.js
+++ b/lib/textlint-engine.js
@@ -23,7 +23,6 @@ function TextLintEngine(options) {
     } else {
         this.config = new Config(options);
     }
-    this.setupRules(this.config);
 }
 /**
  * filter files by config
@@ -71,21 +70,25 @@ TextLintEngine.prototype.setupRules = function (config) {
     textLint.setupRules(ruleManager.getAllRules(), config.rulesConfig);
 };
 /**
+ * set directory to use as root directory to load rule.
+ * @param {string} directory as root directory to load rule
+ */
+TextLintEngine.prototype.setRuleDirectory = function (directory) {
+    this.directory = directory;
+};
+/**
  * load rule file with `ruleName` and define rule.
  * if rule is not found, then throw ReferenceError.
  * if already rule is loaded, do not anything.
  * @param {string} ruleName
- * @param {string} [directory] directory is optional. this value used as root directory to load rule.
  */
-TextLintEngine.prototype.loadRule = function (ruleName, directory) {
+TextLintEngine.prototype.loadRule = function (ruleName) {
     // ignore already defined rule
     // ignore rules from rulePaths because avoid ReferenceError is that try to require.
     if (ruleManager.isDefinedRule(ruleName)) {
         return;
     }
-    if (!directory) {
-        directory = "";
-    }
+    var directory = this.directory || "";
     var pkgPath = tryResolve(path.join(directory, "textlint-rule-" + ruleName)) || tryResolve(path.join(directory, ruleName));
     if (!pkgPath) {
         throw new ReferenceError(ruleName + " is not found");
@@ -107,6 +110,7 @@ TextLintEngine.prototype.resetRules = function () {
  * @returns {TextLintResult[]} The results for all files that were linted.
  */
 TextLintEngine.prototype.executeOnFiles = function (files) {
+    this.setupRules(this.config);
     var targetFiles = findFiles(files, this.config);
     var results = targetFiles.map(function (file) {
         return textLint.lintFile(file);
@@ -122,6 +126,7 @@ TextLintEngine.prototype.executeOnFiles = function (files) {
  * @todo specify the files format for lint by config.filetype?
  */
 TextLintEngine.prototype.executeOnText = function (text) {
+    this.setupRules(this.config);
     var results = [textLint.lintText(text)];
     textLint.resetRules();
     return results;

--- a/lib/textlint-engine.js
+++ b/lib/textlint-engine.js
@@ -74,7 +74,7 @@ TextLintEngine.prototype.setupRules = function (config) {
  * @param {string} directory as root directory to load rule
  */
 TextLintEngine.prototype.setRuleDirectory = function (directory) {
-    this.directory = directory;
+    this.ruleDirectory = directory;
 };
 /**
  * load rule file with `ruleName` and define rule.
@@ -88,7 +88,7 @@ TextLintEngine.prototype.loadRule = function (ruleName) {
     if (ruleManager.isDefinedRule(ruleName)) {
         return;
     }
-    var directory = this.directory || "";
+    var directory = this.ruleDirectory || "";
     var pkgPath = tryResolve(path.join(directory, "textlint-rule-" + ruleName)) || tryResolve(path.join(directory, ruleName));
     if (!pkgPath) {
         throw new ReferenceError(ruleName + " is not found");

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "mkdirp": "^0.5.0",
     "object-assign": "^4.0.1",
     "optionator": "^0.6.0",
-    "path-is-absolute": "^1.0.0",
     "rc-loader": "^1.0.0",
     "textlint-formatter": "^1.1.1",
     "traverse": "^0.6.6",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "mkdirp": "^0.5.0",
     "object-assign": "^4.0.1",
     "optionator": "^0.6.0",
+    "path-is-absolute": "^1.0.0",
     "rc-loader": "^1.0.0",
     "textlint-formatter": "^1.1.1",
     "traverse": "^0.6.6",

--- a/test/textlint-engine-test.js
+++ b/test/textlint-engine-test.js
@@ -118,7 +118,7 @@ describe("cli-engine-test", function () {
             var beforeRuleNames = ruleManger.getAllRuleNames();
             engine.executeOnFiles([filePath]);
             var afterRuleNames = ruleManger.getAllRuleNames();
-            assert.deepStrictEqual(beforeRuleNames, afterRuleNames);
+            assert.deepEqual(beforeRuleNames, afterRuleNames);
         });
     });
     describe("executeOnText", function () {
@@ -141,7 +141,7 @@ describe("cli-engine-test", function () {
             var beforeRuleNames = ruleManger.getAllRuleNames();
             engine.executeOnText("text");
             var afterRuleNames = ruleManger.getAllRuleNames();
-            assert.deepStrictEqual(beforeRuleNames, afterRuleNames);
+            assert.deepEqual(beforeRuleNames, afterRuleNames);
         });
     });
     describe("formatResults", function () {

--- a/test/textlint-engine-test.js
+++ b/test/textlint-engine-test.js
@@ -85,12 +85,10 @@ describe("cli-engine-test", function () {
                 assert(ruleManger.getRule("no-todo") === ruleObject);
             });
         });
-        context("when use directory option", function () {
-            it("should load rule from directory", function () {
+        context("when use absolute path", function () {
+            it("should load rule from path", function () {
                 engine = new TextLintEngine();
-                var directory = __dirname + "/fixtures/rules/";
-                engine.setRuleDirectory(directory);
-                engine.loadRule("example-rule");
+                engine.loadRule(path.join(__dirname, "/fixtures/rules/", "example-rule"));
                 var ruleNames = ruleManger.getAllRuleNames();
                 assert(ruleNames.length === 1);
             });

--- a/test/textlint-engine-test.js
+++ b/test/textlint-engine-test.js
@@ -88,7 +88,7 @@ describe("cli-engine-test", function () {
         context("when use the rule directory", function () {
             it("should load rule from path", function () {
                 engine = new TextLintEngine();
-                engine.setRuleDirectory(path.join(__dirname, "/fixtures/rules/"));
+                engine.setRulesBaseDirectory(path.join(__dirname, "/fixtures/rules/"));
                 engine.addRule("example-rule");
                 engine.setupRules();
                 var ruleNames = ruleManger.getAllRuleNames();
@@ -113,7 +113,7 @@ describe("cli-engine-test", function () {
         });
         it("should lint a file with same rules", function () {
             var filePath = require("path").join(__dirname, "fixtures/test.md");
-            engine.setRuleDirectory(path.join(__dirname, "/fixtures/rules/"));
+            engine.setRulesBaseDirectory(path.join(__dirname, "/fixtures/rules/"));
             engine.addRule("example-rule");
             var beforeRuleNames = ruleManger.getAllRuleNames();
             engine.executeOnFiles([filePath]);
@@ -136,7 +136,7 @@ describe("cli-engine-test", function () {
             assert(lintResult.messages.length > 0);
         });
         it("should lint a text with same rules", function () {
-            engine.setRuleDirectory(path.join(__dirname, "/fixtures/rules/"));
+            engine.setRulesBaseDirectory(path.join(__dirname, "/fixtures/rules/"));
             engine.addRule("example-rule");
             var beforeRuleNames = ruleManger.getAllRuleNames();
             engine.executeOnText("text");

--- a/test/textlint-engine-test.js
+++ b/test/textlint-engine-test.js
@@ -89,7 +89,8 @@ describe("cli-engine-test", function () {
             it("should load rule from directory", function () {
                 engine = new TextLintEngine();
                 var directory = __dirname + "/fixtures/rules/";
-                engine.loadRule("example-rule", directory);
+                engine.setRuleDirectory(directory);
+                engine.loadRule("example-rule");
                 var ruleNames = ruleManger.getAllRuleNames();
                 assert(ruleNames.length === 1);
             });

--- a/test/textlint-engine-test.js
+++ b/test/textlint-engine-test.js
@@ -85,10 +85,12 @@ describe("cli-engine-test", function () {
                 assert(ruleManger.getRule("no-todo") === ruleObject);
             });
         });
-        context("when use absolute path", function () {
+        context("when use the rule directory", function () {
             it("should load rule from path", function () {
                 engine = new TextLintEngine();
-                engine.loadRule(path.join(__dirname, "/fixtures/rules/", "example-rule"));
+                engine.setRuleDirectory(path.join(__dirname, "/fixtures/rules/"));
+                engine.addRule("example-rule");
+                engine.setupRules();
                 var ruleNames = ruleManger.getAllRuleNames();
                 assert(ruleNames.length === 1);
             });
@@ -109,6 +111,15 @@ describe("cli-engine-test", function () {
             assert(Array.isArray(fileResult.messages));
             assert(fileResult.messages.length > 0);
         });
+        it("should lint a file with same rules", function () {
+            var filePath = require("path").join(__dirname, "fixtures/test.md");
+            engine.setRuleDirectory(path.join(__dirname, "/fixtures/rules/"));
+            engine.addRule("example-rule");
+            var beforeRuleNames = ruleManger.getAllRuleNames();
+            engine.executeOnFiles([filePath]);
+            var afterRuleNames = ruleManger.getAllRuleNames();
+            assert.deepStrictEqual(beforeRuleNames, afterRuleNames);
+        });
     });
     describe("executeOnText", function () {
         beforeEach(function () {
@@ -123,6 +134,14 @@ describe("cli-engine-test", function () {
             assert(lintResult.filePath === "<text>");
             assert(Array.isArray(lintResult.messages));
             assert(lintResult.messages.length > 0);
+        });
+        it("should lint a text with same rules", function () {
+            engine.setRuleDirectory(path.join(__dirname, "/fixtures/rules/"));
+            engine.addRule("example-rule");
+            var beforeRuleNames = ruleManger.getAllRuleNames();
+            engine.executeOnText("text");
+            var afterRuleNames = ruleManger.getAllRuleNames();
+            assert.deepStrictEqual(beforeRuleNames, afterRuleNames);
         });
     });
     describe("formatResults", function () {


### PR DESCRIPTION
- `TextLintEngine.prototype.executeOnFiles`
- `TextLintEngine.prototype.executeOnText`

のタイミングで都度`setupRules`を実行していますが、`config`が渡されるタイミング（現状`TextLintEngine`のコンストラクタのみ）の方がパフォーマンス的にも良さそうです