### PR TITLE
docs(txtnode): why line of location start with 1?

### DIFF
--- a/docs/txtnode.d.ts
+++ b/docs/txtnode.d.ts
@@ -10,11 +10,13 @@ declare module TxtSyntax {
         children?: TxtNode[];
     }
     interface LineLocation {
-        start: Position
-        end: Position
+        start: Position;
+        end: Position;
     }
     interface Position {
-        line: number
-        column: number
+        line: number; // start with 1
+        column: number;// start with 0
+        // This is for compatibility with JavaScript AST.
+        // https://gist.github.com/azu/8866b2cb9b7a933e01fe
     }
 }

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -88,6 +88,13 @@ module.exports = function (context) {
 }
 ```
 
+- `line` start with 1 (1-indexed).
+- `column` start with 0 (0-indexed).
+
+This is for compatibility with JavaScript AST.
+
+- [Why do `line` of location in JavaScript AST(ESTree) start with 1 and not 0?](https://gist.github.com/azu/8866b2cb9b7a933e01fe "Why do `line` of location in JavaScript AST(ESTree) start with 1 and not 0?")
+
 ## Warning
 
 Other properties is not assured.

--- a/src/textlint-core.js
+++ b/src/textlint-core.js
@@ -155,6 +155,7 @@ export default class TextlintCore extends EventEmitter {
         this.messages.push(objectAssign({
             ruleId: ruleId,
             message: error.message,
+            // See https://github.com/azu/textlint/blob/master/docs/txtnode.md#loc
             line: error.line ? txtNode.loc.start.line + error.line : txtNode.loc.start.line,
             column: error.column ? txtNode.loc.start.column + error.column : txtNode.loc.start.column,
             severity: 2


### PR DESCRIPTION
Add docs about location indexed.

```
    interface Position {
        line: number; // start with 1
        column: number;// start with 0
        // This is for compatibility with JavaScript AST.
        // https://gist.github.com/azu/8866b2cb9b7a933e01fe
    }
```

- `line` - 1-indexed
- `column` - 0-indexed