### PR TITLE
allow an empty text with lint

### DIFF
--- a/src/textlint-core.js
+++ b/src/textlint-core.js
@@ -95,7 +95,6 @@ export default class TextlintCore extends EventEmitter {
     }
 
     _lintByProcessor(processor, text, ext, filePath) {
-        require('assert')(text.length > 0);
         this.initializeForLinting(text);
         require('assert')(processor, `processor is not found for ${ext}`);
         const {preProcess, postProcess} = processor.processor(ext);

--- a/test/textlint-core-test.js
+++ b/test/textlint-core-test.js
@@ -16,6 +16,20 @@ describe("textlint-core", function () {
             assert(results2.messages.length === 0);
         });
     });
+    context("when a linting text is empty", function () {
+      it("should not throw an exceptoin", function () {
+        var textlint = new TextLintCore();
+        textlint.setupRules({
+            "example-rule": rule
+        });
+        var result1 = textlint.lintText("");
+        assert(result1.messages.length === 0);
+        var result2 = textlint.lintMarkdown("");
+        assert(result2.messages.length === 0);
+        var result3 = textlint.lintFile('./test/fixtures/empty.md');
+        assert(result3.messages.length === 0);
+      });
+    });
     describe("ruleConfig", function () {
         context("when set ruleConfig.severity", function () {
             it("message.severity should used the config", function () {


### PR DESCRIPTION
Currently, textlint throws an exception when it checks an empty text(file).

* stacktrace

```
AssertionError: false == true
    at TextlintCore._lintByProcessor (/Users/koba04/github/textlint/lib/textlint-core.js:133:30)
    at TextlintCore.lintFile (/Users/koba04/github/textlint/lib/textlint-core.js:203:25)
    at /Users/koba04/github/textlint/lib/textlint-engine.js:196:33
    at Array.map (native)
    at TextLintEngine.executeOnFiles (/Users/koba04/github/textlint/lib/textlint-engine.js:195:39)
    at Object.execute (/Users/koba04/github/textlint/lib/cli.js:75:70)
    at Object.<anonymous> (/Users/koba04/github/textlint/bin/textlint.js:14:20)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
```

This PR is for textlint allows an empty text(file).

What does it mean this assert?
if this assert is necessary, I'd like to add a message to `assert`.

```js
require('assert')(text.length > 0, "textlint doesn't allow an empty text");
```

Thanks!