### PR TITLE
refactor(engine): directly use textlint-core

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -63,10 +63,7 @@ class Config {
      * @returns {Config}
      * @constructor
      */
-    constructor(options) {
-        if (typeof options === 'undefined') {
-            return objectAssign(this, defaultOptions);
-        }
+    constructor(options = {}) {
         // TODO: add `noUseConfig` option
         // configFile is optional
         // => load .textlintrc

--- a/src/textlint-core.js
+++ b/src/textlint-core.js
@@ -7,7 +7,6 @@
 const objectAssign = require('object-assign');
 const TraverseController = require('txt-ast-traverse').Controller;
 const RuleContext = require('./rule/rule-context');
-const RuleManager = require('./rule/rule-manager');
 const isMarkdown = require('is-md');
 const path = require('path');
 const fs = require('fs');
@@ -104,7 +103,6 @@ export default class TextlintCore {
             new TextProcessor(config),
             new HTMLProcessor(config)
         ];
-        this.ruleManager = new RuleManager();
         this.ruleContextAgent = new RuleContextAgent();
     }
 
@@ -151,7 +149,6 @@ export default class TextlintCore {
      */
     resetRules() {
         this.ruleContextAgent.removeAllListeners();
-        this.ruleManager.resetRules();
     }
 
     _lintByProcessor(processor, text, ext, filePath) {

--- a/src/textlint-engine.js
+++ b/src/textlint-engine.js
@@ -31,6 +31,7 @@ class TextLintEngine {
         this.ruleManager = new RuleManager();
         // default Processor Constructors
         this.Processors = [MarkdownProcessor, TextProcessor, HTMLProcessor];
+        this._setupRules(this.config);
     }
 
     /**
@@ -38,7 +39,7 @@ class TextLintEngine {
      * The {@lint Config} object was created with initialized {@link TextLintEngine} (as-known Constructor).
      * @param {Config} config the config is parsed object
      */
-    setupRules(config = this.config) {
+    _setupRules(config) {
         debug('config %O', config);
         // --ruledir
         if (config.rulePaths) {
@@ -79,6 +80,7 @@ class TextLintEngine {
     addRule(ruleName) {
         if (Array.isArray(this.config.rules) && this.config.rules.indexOf(ruleName) === -1) {
             this.config.rules.push(ruleName);
+            this._setupRules(this.config);
         }
     }
 
@@ -88,6 +90,7 @@ class TextLintEngine {
      */
     setRulesBaseDirectory(directory) {
         this.config.rulesBaseDirectory = directory;
+        this._setupRules(this.config);
     }
 
     /**
@@ -139,6 +142,7 @@ class TextLintEngine {
      * Remove all registered rule and clear messages.
      */
     resetRules() {
+        this.textLint.resetRules();
         this.ruleManager.resetRules();
     }
 
@@ -148,8 +152,6 @@ class TextLintEngine {
      * @returns {TextLintResult[]} The results for all files that were linted.
      */
     executeOnFiles(files) {
-        console.log(this.config);
-        this.setupRules(this.config);
         let availableExtensions = this.config.extensions;
         // execute files that are filtered by availableExtensions.
         this.Processors.forEach(Processor => {
@@ -159,7 +161,6 @@ class TextLintEngine {
         const results = targetFiles.map(file => {
             return this.textLint.lintFile(file);
         });
-        this.textLint.resetRules();
         return results;
     }
 
@@ -171,9 +172,7 @@ class TextLintEngine {
      * @returns {TextLintResult[]}
      */
     executeOnText(text, ext = ".txt") {
-        this.setupRules(this.config);
         const results = [this.textLint.lintText(text, ext)];
-        this.textLint.resetRules();
         return results;
     }
 

--- a/src/textlint-engine.js
+++ b/src/textlint-engine.js
@@ -38,6 +38,7 @@ class TextLintEngine {
      * set up lint rules using {@lint Config} object.
      * The {@lint Config} object was created with initialized {@link TextLintEngine} (as-known Constructor).
      * @param {Config} config the config is parsed object
+     * @private
      */
     _setupRules(config) {
         debug('config %O', config);

--- a/src/textlint-engine.js
+++ b/src/textlint-engine.js
@@ -87,6 +87,13 @@ class TextLintEngine {
     /**
      * set directory to use as root directory to load rule.
      * @param {string} directory as root directory to load rule
+     * @deprecated please use
+     *
+     * ```
+     * new TextLintEngine({
+     *  rulesBaseDirectory: directory
+     * })
+     * ```
      */
     setRulesBaseDirectory(directory) {
         this.config.rulesBaseDirectory = directory;

--- a/test/textlint-engine-test.js
+++ b/test/textlint-engine-test.js
@@ -4,7 +4,7 @@ var assert = require("power-assert");
 var TextLintEngine = require("../src/").TextLintEngine;
 var rulesDir = __dirname + "/fixtures/rules";
 var path = require('path');
-describe("cli-engine-test", function () {
+describe("textlint-engine-test", function () {
     var engine;
     afterEach(function () {
         engine.resetRules();
@@ -41,7 +41,6 @@ describe("cli-engine-test", function () {
                 engine = new TextLintEngine({
                     rules: ["no-todo"]
                 });
-                engine.setupRules();
                 var ruleNames = engine.ruleManager.getAllRuleNames();
                 assert(ruleNames.length > 0);
                 assert.equal(ruleNames[0], "no-todo");
@@ -52,7 +51,6 @@ describe("cli-engine-test", function () {
                 engine = new TextLintEngine({
                     rules: ["textlint-rule-no-todo"]
                 });
-                engine.setupRules();
                 var ruleNames = engine.ruleManager.getAllRuleNames();
                 assert(ruleNames.length > 0);
                 assert.equal(ruleNames[0], "no-todo");
@@ -114,7 +112,6 @@ describe("cli-engine-test", function () {
                 engine = new TextLintEngine();
                 engine.setRulesBaseDirectory(path.join(__dirname, "/fixtures/rules/"));
                 engine.addRule("example-rule");
-                engine.setupRules();
                 var ruleNames = engine.ruleManager.getAllRuleNames();
                 assert(ruleNames.length === 1);
             });
@@ -137,7 +134,7 @@ describe("cli-engine-test", function () {
             engine = new TextLintEngine();
             var filePath = path.join(__dirname, "fixtures/test.md");
             engine.setRulesBaseDirectory(path.join(__dirname, "/fixtures/rules/"));
-            engine.loadRule("example-rule");
+            engine.addRule("example-rule");
             var beforeRuleNames = engine.ruleManager.getAllRuleNames();
             engine.executeOnFiles([filePath]);
             var afterRuleNames = engine.ruleManager.getAllRuleNames();

--- a/test/textlint-engine-test.js
+++ b/test/textlint-engine-test.js
@@ -5,20 +5,16 @@ var TextLintEngine = require("../src/").TextLintEngine;
 var rulesDir = __dirname + "/fixtures/rules";
 var path = require('path');
 describe("textlint-engine-test", function () {
-    var engine;
-    afterEach(function () {
-        engine.resetRules();
-    });
     describe("Constructor", function () {
         context("when no-args", function () {
             it("config should be empty", function () {
-                engine = new TextLintEngine();
+                let engine = new TextLintEngine();
                 assert.deepEqual(engine.config.rulePaths, []);
             });
         });
         context("when args is object", function () {
             it("should convert the object and set config", function () {
-                engine = new TextLintEngine({
+                let engine = new TextLintEngine({
                     rulePaths: [rulesDir]
                 });
                 assert.deepEqual(engine.config.rulePaths, [rulesDir]);
@@ -30,7 +26,7 @@ describe("textlint-engine-test", function () {
                 var Config = require("../src/config/config");
                 var config = new Config();
                 config.rulePaths = [rulesDir];
-                engine = new TextLintEngine(config);
+                let engine = new TextLintEngine(config);
                 assert.deepEqual(engine.config.rulePaths, [rulesDir]);
             });
         });
@@ -38,7 +34,7 @@ describe("textlint-engine-test", function () {
     describe("setup rule", function () {
         context("when (textlint-rule-)no-todo is specified", function () {
             it("should set `no-todo` as key to rule dict", function () {
-                engine = new TextLintEngine({
+                let engine = new TextLintEngine({
                     rules: ["no-todo"]
                 });
                 var ruleNames = engine.ruleManager.getAllRuleNames();
@@ -48,7 +44,7 @@ describe("textlint-engine-test", function () {
         });
         context("when textlint-rule-no-todo is specified", function () {
             it("should set `no-todo` as key to rule dict", function () {
-                engine = new TextLintEngine({
+                let engine = new TextLintEngine({
                     rules: ["textlint-rule-no-todo"]
                 });
                 var ruleNames = engine.ruleManager.getAllRuleNames();
@@ -60,7 +56,7 @@ describe("textlint-engine-test", function () {
     describe("#loadPlugin", function () {
         context("when the rule is **not** defined", function () {
             it("should define rules of plugin", function () {
-                engine = new TextLintEngine();
+                let engine = new TextLintEngine();
                 engine.setRulesBaseDirectory(path.join(__dirname, "/fixtures/plugins/"));
                 engine.loadPlugin("example");
                 var ruleNames = engine.ruleManager.getAllRuleNames();
@@ -70,7 +66,7 @@ describe("textlint-engine-test", function () {
         });
         context("when the rule is defined", function () {
             it("should not re-load rule", function () {
-                engine = new TextLintEngine();
+                let engine = new TextLintEngine();
                 engine.setRulesBaseDirectory(path.join(__dirname, "/fixtures/plugins/"));
                 engine.loadPlugin("example");
                 var ruleNames = engine.ruleManager.getAllRuleNames();
@@ -87,7 +83,7 @@ describe("textlint-engine-test", function () {
     describe("#loadRule", function () {
         context("when the rule is **not** defined", function () {
             it("should define the rule", function () {
-                engine = new TextLintEngine();
+                let engine = new TextLintEngine();
                 engine.loadRule("textlint-rule-no-todo");
                 var ruleNames = engine.ruleManager.getAllRuleNames();
                 assert(ruleNames.length > 0);
@@ -96,7 +92,7 @@ describe("textlint-engine-test", function () {
         });
         context("when the rule is defined", function () {
             it("should not re-load rule", function () {
-                engine = new TextLintEngine();
+                let engine = new TextLintEngine();
                 engine.loadRule("textlint-rule-no-todo");
                 var ruleNames = engine.ruleManager.getAllRuleNames();
                 assert(ruleNames.length === 1);
@@ -109,7 +105,7 @@ describe("textlint-engine-test", function () {
         });
         context("when use the rule directory", function () {
             it("should load rule from path", function () {
-                engine = new TextLintEngine();
+                let engine = new TextLintEngine();
                 engine.setRulesBaseDirectory(path.join(__dirname, "/fixtures/rules/"));
                 engine.addRule("example-rule");
                 var ruleNames = engine.ruleManager.getAllRuleNames();
@@ -119,7 +115,7 @@ describe("textlint-engine-test", function () {
     });
     describe("executeOnFiles", function () {
         it("should found error message", function () {
-            engine = new TextLintEngine({
+            let engine = new TextLintEngine({
                 rulePaths: [rulesDir]
             });
             var filePath = path.join(__dirname, "fixtures/test.md");
@@ -131,7 +127,7 @@ describe("textlint-engine-test", function () {
             assert(fileResult.messages.length > 0);
         });
         it("should lint a file with same rules", function () {
-            engine = new TextLintEngine();
+            let engine = new TextLintEngine();
             var filePath = path.join(__dirname, "fixtures/test.md");
             engine.setRulesBaseDirectory(path.join(__dirname, "/fixtures/rules/"));
             engine.addRule("example-rule");
@@ -142,16 +138,17 @@ describe("textlint-engine-test", function () {
         });
         context("when process file that has un-available ext ", function () {
             it("should return empty results ", function () {
+                let engine = new TextLintEngine();
                 var filePath = path.join(__dirname, "fixtures/test.unknown");
                 var results = engine.executeOnFiles([filePath]);
                 assert(Array.isArray(results));
                 assert(results.length === 0);
             });
-        })
+        });
     });
     describe("executeOnText", function () {
         it("should lint a text and return results", function () {
-            engine = new TextLintEngine({
+            let engine = new TextLintEngine({
                 rulePaths: [rulesDir]
             });
             var results = engine.executeOnText("text");
@@ -162,7 +159,7 @@ describe("textlint-engine-test", function () {
             assert(lintResult.messages.length > 0);
         });
         it("should lint a text with same rules", function () {
-            engine = new TextLintEngine();
+            let engine = new TextLintEngine();
             engine.setRulesBaseDirectory(path.join(__dirname, "/fixtures/rules/"));
             engine.loadRule("example-rule");
             var beforeRuleNames = engine.ruleManager.getAllRuleNames();
@@ -173,12 +170,10 @@ describe("textlint-engine-test", function () {
     });
     describe("formatResults", function () {
         context("when use default formatter", function () {
-            beforeEach(function () {
-                engine = new TextLintEngine({
+            it("should format results and return formatted text", function () {
+                let engine = new TextLintEngine({
                     rulePaths: [rulesDir]
                 });
-            });
-            it("should format results and return formatted text", function () {
                 var results = engine.executeOnText("text");
                 var output = engine.formatResults(results);
                 assert(/<text>/.test(output));
@@ -186,18 +181,26 @@ describe("textlint-engine-test", function () {
             });
         });
         context("when loaded custom formatter", function () {
-            beforeEach(function () {
-                engine = new TextLintEngine({
+            it("should return custom formatted text", function () {
+                let engine = new TextLintEngine({
                     rulePaths: [rulesDir],
                     formatterName: path.join(__dirname, "fixtures/formatter/example-formatter.js")
                 });
-            });
-            it("should return custom formatted text", function () {
                 var results = engine.executeOnText("text");
                 var output = engine.formatResults(results);
                 assert(!/<text>/.test(output));
                 assert(/example-formatter/.test(output));
             });
-        })
+        });
+    });
+    // TODO: deprecated method
+    describe("#setRulesBaseDirectory", function () {
+        it("should change rulesBaseDirectory of config", function () {
+            let engine = new TextLintEngine();
+            var directory = path.join(__dirname, "/fixtures/rules/");
+            engine.setRulesBaseDirectory(directory);
+            assert.equal(engine.config.rulesBaseDirectory, directory);
+        });
     });
 });
+

--- a/test/textlint-engine-test.js
+++ b/test/textlint-engine-test.js
@@ -2,14 +2,12 @@
 "use strict";
 var assert = require("power-assert");
 var TextLintEngine = require("../src/").TextLintEngine;
-var textlint = require("../src/").textlint;
 var rulesDir = __dirname + "/fixtures/rules";
-var path = require("path");
+var path = require('path');
 describe("cli-engine-test", function () {
     var engine;
     afterEach(function () {
         engine.resetRules();
-        textlint.resetRules();
     });
     describe("Constructor", function () {
         context("when no-args", function () {
@@ -44,7 +42,7 @@ describe("cli-engine-test", function () {
                     rules: ["no-todo"]
                 });
                 engine.setupRules();
-                var ruleNames = textlint.ruleManager.getAllRuleNames();
+                var ruleNames = engine.ruleManager.getAllRuleNames();
                 assert(ruleNames.length > 0);
                 assert.equal(ruleNames[0], "no-todo");
             });
@@ -55,7 +53,7 @@ describe("cli-engine-test", function () {
                     rules: ["textlint-rule-no-todo"]
                 });
                 engine.setupRules();
-                var ruleNames = textlint.ruleManager.getAllRuleNames();
+                var ruleNames = engine.ruleManager.getAllRuleNames();
                 assert(ruleNames.length > 0);
                 assert.equal(ruleNames[0], "no-todo");
             });
@@ -67,7 +65,7 @@ describe("cli-engine-test", function () {
                 engine = new TextLintEngine();
                 engine.setRulesBaseDirectory(path.join(__dirname, "/fixtures/plugins/"));
                 engine.loadPlugin("example");
-                var ruleNames = textlint.ruleManager.getAllRuleNames();
+                var ruleNames = engine.ruleManager.getAllRuleNames();
                 assert(ruleNames.length > 0);
                 assert.equal(ruleNames[0], "example/example-rule");
             });
@@ -77,13 +75,13 @@ describe("cli-engine-test", function () {
                 engine = new TextLintEngine();
                 engine.setRulesBaseDirectory(path.join(__dirname, "/fixtures/plugins/"));
                 engine.loadPlugin("example");
-                var ruleNames = textlint.ruleManager.getAllRuleNames();
+                var ruleNames = engine.ruleManager.getAllRuleNames();
                 assert(ruleNames.length === 1);
-                var ruleObject = textlint.ruleManager.getRule(ruleNames[0]);
+                var ruleObject = engine.ruleManager.getRule(ruleNames[0]);
                 // loadRule should ignore
                 engine.loadPlugin("example");
                 // should equal prev loaded object
-                assert(textlint.ruleManager.getRule("example/example-rule") === ruleObject);
+                assert(engine.ruleManager.getRule("example/example-rule") === ruleObject);
             });
         });
     });
@@ -93,7 +91,7 @@ describe("cli-engine-test", function () {
             it("should define the rule", function () {
                 engine = new TextLintEngine();
                 engine.loadRule("textlint-rule-no-todo");
-                var ruleNames = textlint.ruleManager.getAllRuleNames();
+                var ruleNames = engine.ruleManager.getAllRuleNames();
                 assert(ruleNames.length > 0);
                 assert.equal(ruleNames[0], "no-todo");
             });
@@ -102,13 +100,13 @@ describe("cli-engine-test", function () {
             it("should not re-load rule", function () {
                 engine = new TextLintEngine();
                 engine.loadRule("textlint-rule-no-todo");
-                var ruleNames = textlint.ruleManager.getAllRuleNames();
+                var ruleNames = engine.ruleManager.getAllRuleNames();
                 assert(ruleNames.length === 1);
-                var ruleObject = textlint.ruleManager.getRule(ruleNames[0]);
+                var ruleObject = engine.ruleManager.getRule(ruleNames[0]);
                 // loadRule should ignore
                 engine.loadRule("textlint-rule-no-todo");
                 // should equal prev loaded object
-                assert(textlint.ruleManager.getRule("no-todo") === ruleObject);
+                assert(engine.ruleManager.getRule("no-todo") === ruleObject);
             });
         });
         context("when use the rule directory", function () {
@@ -117,18 +115,16 @@ describe("cli-engine-test", function () {
                 engine.setRulesBaseDirectory(path.join(__dirname, "/fixtures/rules/"));
                 engine.addRule("example-rule");
                 engine.setupRules();
-                var ruleNames = textlint.ruleManager.getAllRuleNames();
+                var ruleNames = engine.ruleManager.getAllRuleNames();
                 assert(ruleNames.length === 1);
             });
         });
     });
     describe("executeOnFiles", function () {
-        beforeEach(function () {
+        it("should found error message", function () {
             engine = new TextLintEngine({
                 rulePaths: [rulesDir]
             });
-        });
-        it("should found error message", function () {
             var filePath = path.join(__dirname, "fixtures/test.md");
             var results = engine.executeOnFiles([filePath]);
             assert(Array.isArray(results));
@@ -138,12 +134,13 @@ describe("cli-engine-test", function () {
             assert(fileResult.messages.length > 0);
         });
         it("should lint a file with same rules", function () {
+            engine = new TextLintEngine();
             var filePath = path.join(__dirname, "fixtures/test.md");
             engine.setRulesBaseDirectory(path.join(__dirname, "/fixtures/rules/"));
-            engine.addRule("example-rule");
-            var beforeRuleNames = textlint.ruleManager.getAllRuleNames();
+            engine.loadRule("example-rule");
+            var beforeRuleNames = engine.ruleManager.getAllRuleNames();
             engine.executeOnFiles([filePath]);
-            var afterRuleNames = textlint.ruleManager.getAllRuleNames();
+            var afterRuleNames = engine.ruleManager.getAllRuleNames();
             assert.deepEqual(beforeRuleNames, afterRuleNames);
         });
         context("when process file that has un-available ext ", function () {
@@ -156,12 +153,10 @@ describe("cli-engine-test", function () {
         })
     });
     describe("executeOnText", function () {
-        beforeEach(function () {
+        it("should lint a text and return results", function () {
             engine = new TextLintEngine({
                 rulePaths: [rulesDir]
             });
-        });
-        it("should lint a text and return results", function () {
             var results = engine.executeOnText("text");
             assert(Array.isArray(results));
             var lintResult = results[0];
@@ -170,11 +165,12 @@ describe("cli-engine-test", function () {
             assert(lintResult.messages.length > 0);
         });
         it("should lint a text with same rules", function () {
+            engine = new TextLintEngine();
             engine.setRulesBaseDirectory(path.join(__dirname, "/fixtures/rules/"));
-            engine.addRule("example-rule");
-            var beforeRuleNames = textlint.ruleManager.getAllRuleNames();
+            engine.loadRule("example-rule");
+            var beforeRuleNames = engine.ruleManager.getAllRuleNames();
             engine.executeOnText("text");
-            var afterRuleNames = textlint.ruleManager.getAllRuleNames();
+            var afterRuleNames = engine.ruleManager.getAllRuleNames();
             assert.deepEqual(beforeRuleNames, afterRuleNames);
         });
     });


### PR DESCRIPTION
no use textlint.js(singleton) in textlint-engine.js

I think this change make linting phase more scalable.